### PR TITLE
Adds alternative biome edge detection test command

### DIFF
--- a/Canopy [BP]/scripts/main.js
+++ b/Canopy [BP]/scripts/main.js
@@ -31,6 +31,7 @@ import './src/commands/loop'
 import './src/commands/debugentity'
 import './src/commands/hss'
 import './src/commands/biomeedges'
+import './src/commands/biomeedgestest'
 
 // Script Events
 import './src/commands/scriptevents/counter'

--- a/Canopy [BP]/scripts/src/classes/BiomeEdgeFinderTest.js
+++ b/Canopy [BP]/scripts/src/classes/BiomeEdgeFinderTest.js
@@ -1,0 +1,122 @@
+import { BlockVolume, system } from "@minecraft/server";
+import { BiomeEdgeRendererTest } from "./BiomeEdgeRendererTest";
+import { Vector } from "../../lib/Vector";
+
+export class BiomeEdgeFinderTest {
+    probeEntityId = 'canopy:probe';
+    dimension;
+    blockVolume;
+    biomeLocations = {}; 
+    renderer;
+    shouldStop = false;
+    availableProbeEntities = [];
+    inUseProbeEntities = [];
+    populationRunner = null;
+    analysisRunner = null;
+
+    constructor(dimension, fromLocation, toLocation) {
+        this.dimension = dimension;
+        this.blockVolume = new BlockVolume(fromLocation, toLocation);
+        this.renderBiomeEdges();
+    }
+
+    destroy() {
+        this.shouldStop = true;
+        this.removeProbeEntities();
+        this.stopRenderer();
+        this.biomeLocations = {};
+        this.blockVolume = null;
+        this.dimension = null;
+        this.renderer = null;
+    }
+
+    renderBiomeEdges() {
+        this.startRenderer();
+        this.populationRunner = system.runJob(this.populateBiomeLocations());
+        this.waitForJobCompletion(() => this.populationRunner, () => this.renderer.drawBiomeEdges(this.biomeLocations));
+    }
+
+    startRenderer() {
+        this.renderer = new BiomeEdgeRendererTest(this.blockVolume);
+    }
+
+    stopRenderer() {
+        if (this.renderer) {
+            this.renderer.destroy();
+            this.renderer = null;
+        }
+    }
+
+    *populateBiomeLocations() {
+        const blockLocationIterator = this.blockVolume.getBlockLocationIterator();
+        let result = blockLocationIterator.next();
+        while (!result.done && !this.shouldStop && this.renderer) {
+            this.renderer.renderAnalysisLocation(result.value);
+            this.addBiomeAtLocation(result.value);
+            yield void 0;
+            if (this.shouldStop)
+                break;
+            result = blockLocationIterator.next();
+        }
+        system.runTimeout(() => {
+            this.populationRunner = null;
+            this.removeProbeEntities();
+        }, 2);
+    }
+
+    addBiomeAtLocation(location) {
+        const probeEntity = this.getAvailableProbeEntity(location);
+        system.runTimeout(() => {
+            if (probeEntity?.isValid) {
+                const vectorLocation = Vector.from(location);
+                const biome = probeEntity.getProperty('canopy:biome');
+                if (!biome)
+                    console.warn(`Biome not found for location ${vectorLocation.toString()}`);
+                this.biomeLocations[vectorLocation] = { location: vectorLocation, biome };
+                this.inUseProbeEntities.splice(this.inUseProbeEntities.indexOf(probeEntity), 1);
+                this.availableProbeEntities.push(probeEntity);
+            }
+        }, 2);
+    }
+    
+    getAvailableProbeEntity(location) {
+        let entity = this.availableProbeEntities.pop();
+        if (entity?.isValid) {
+            entity.teleport(location, { dimension: this.dimension });
+        } else {
+            try {
+                entity = this.dimension.spawnEntity(this.probeEntityId, location);
+            } catch (error) {
+                if (['LocationOutOfWorldBoundariesError', 'LocationInUnloadedChunkError'].includes(error.name))
+                    return void 0;
+                throw error;
+            }
+        }
+        this.inUseProbeEntities.push(entity);
+        return entity;
+    }
+
+    removeProbeEntities() {
+        this.availableProbeEntities.forEach(entity => {
+            if (entity?.isValid)
+                entity.remove();
+        });
+        this.inUseProbeEntities.forEach(entity => {
+            if (entity?.isValid)
+                entity.remove();
+        });
+    }
+
+    waitForJobCompletion(jobStatusCallback, completionCallback) {
+        const waitRunner = system.runInterval(() => {
+            if (this.shouldStop) {
+                system.clearRun(waitRunner);
+                return;
+            }
+            if (jobStatusCallback() === null) {
+                completionCallback();
+                system.clearRun(waitRunner);
+            }
+        }, 1);
+    }
+}

--- a/Canopy [BP]/scripts/src/classes/BiomeEdgeRendererTest.js
+++ b/Canopy [BP]/scripts/src/classes/BiomeEdgeRendererTest.js
@@ -4,7 +4,7 @@ import { hexToRGB } from "../../include/utils";
 import { system } from "@minecraft/server";
 import { Vector } from "../../lib/Vector";
 
-export class BiomeEdgeRenderer {
+export class BiomeEdgeRendererTest {
     biomeLocations = {};
     shapes = [];
     shouldStop = false;
@@ -79,29 +79,46 @@ export class BiomeEdgeRenderer {
 
     *generateMeshFromMask(mask, middleAxis, finalAxis, span, localLocation) {
         let maskIndex = 0;
+        let prevLocalLocation = localLocation
         for (let finalAxisIndex = 0; finalAxisIndex < span[finalAxis]; ++finalAxisIndex) {
             let middleAxisIndex = 0;
+            let middle = false
+            let start = true
             while (middleAxisIndex < span[middleAxis]) {
                 if (this.shouldStop)
                     return;
-                if (mask[maskIndex]) {
-                    const { quadWidth, quadHeight } = this.findQuad(mask, maskIndex, middleAxisIndex, finalAxisIndex, span, middleAxis, finalAxis);
-                    // const  quadWidth = 1;
-                    // const quadHeight = 1; 
+                if ((mask[maskIndex] && !middle))  {
+                    const quadWidth = 1
+                    const quadHeight = 1
                     localLocation[middleAxis] = middleAxisIndex;
                     localLocation[finalAxis] = finalAxisIndex;
-                    this.drawQuad(localLocation, middleAxis, finalAxis, quadWidth, quadHeight);
+
+                    // this.drawLine(localLocation, middleAxis, finalAxis, 0, quadHeight, start);
+                    if (start) {
+                        this.drawQuad(prevLocalLocation, middleAxis, finalAxis, 1, quadHeight, 1)
+                        start=false
+                    } else {
+                        this.drawQuad(localLocation, middleAxis, finalAxis, 0, quadHeight, 0) }
                     this.clearMaskOfQuad(mask, maskIndex, quadWidth, quadHeight, span[middleAxis]);
                     middleAxisIndex += quadWidth;
                     maskIndex += quadWidth;
-                } else {
+                    middle = true
+                    prevLocalLocation[middleAxis] = localLocation[middleAxis]
+                    prevLocalLocation[finalAxis] = localLocation[finalAxis]
+
+                } else if (middle && !mask[maskIndex]){
+                    middle = false
+                    start = true
+                } else if (middle || !mask[maskIndex]){
                     middleAxisIndex++;
                     maskIndex++;
-                }
+                } 
                 yield void 0;
             }
         }
     }
+
+
 
     findQuad(mask, maskIndex, middleAxisIndex, finalAxisIndex, span, middleAxis, finalAxis) {
         let quadWidth = 1;
@@ -134,7 +151,16 @@ export class BiomeEdgeRenderer {
         }
     }
 
-    drawQuad(localLocation, middleAxis, finalAxis, quadWidth, quadHeight) {
+    drawLines(localLocation, middleAxis, finalAxis, length, start) {
+        
+        const worldLocation1 = Vector.from(this.blockVolume.getMin()).add(new Vector(...localLocation));
+        
+        const sidedBox = new DebugLine(worldLocation1, );
+        sidedBox.color = { red: 1, green: 0, blue: 0 };
+        this.drawShape(sidedBox);
+    }
+
+    drawQuad(localLocation, middleAxis, finalAxis, quadWidth, quadHeight, debug) {
         const changeInMiddleAxis = [0, 0, 0];
         changeInMiddleAxis[middleAxis] = quadWidth;
         const changeInFinalAxis = [0, 0, 0];
@@ -144,7 +170,7 @@ export class BiomeEdgeRenderer {
         const worldLocation = Vector.from(this.blockVolume.getMin()).add(new Vector(...localLocation));
         const sidedBox = new DebugBox(worldLocation);
         sidedBox.bound = bound;
-        sidedBox.color = { red: 1, green: 1, blue: 1 };
+        sidedBox.color = { red: debug, green: 1, blue: 0 };
         this.drawShape(sidedBox);
     }
 


### PR DESCRIPTION
Introduces an aternative command to visualize and test biome edge detection.

- Implements a new command `biomeedgestest` for in-game testing.
- Includes a basic biome edge finding and rendering system.