### PR TITLE
Centralize Vitest @minecraft mocks into __mocks__ files

### DIFF
--- a/__mocks__/@minecraft/server-ui.js
+++ b/__mocks__/@minecraft/server-ui.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { vi } from 'vitest';
 
 export const FormCancelationReason = {

--- a/__mocks__/@minecraft/server-ui.js
+++ b/__mocks__/@minecraft/server-ui.js
@@ -1,8 +1,13 @@
+import { vi } from 'vitest';
+
 export const FormCancelationReason = {
-    UserBusy: "UserBusy",
-    UserClosed: "UserClosed",
-}
+    UserBusy: 'UserBusy',
+    UserClosed: 'UserClosed',
+};
+
 export const uiManager = {
-    closeAllForms: () => {}
-}
-export const ActionFormData = {};
+    closeAllForms: vi.fn(),
+};
+
+export class ModalFormData {}
+export class ActionFormData {}

--- a/__mocks__/@minecraft/server.js
+++ b/__mocks__/@minecraft/server.js
@@ -1,11 +1,70 @@
-export const world = {};
-export const system = {};
-export const ItemStack = {};
+import { vi } from 'vitest';
+
+export const world = {
+    beforeEvents: {
+        chatSend: { subscribe: vi.fn() },
+        playerPlaceBlock: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+        entityRemove: { subscribe: vi.fn() },
+        playerLeave: { subscribe: vi.fn() },
+    },
+    afterEvents: {
+        worldLoad: { subscribe: vi.fn() },
+        entitySpawn: { subscribe: vi.fn() },
+        playerInventoryItemChange: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+        pistonActivate: { subscribe: vi.fn() },
+    },
+    getDimension: vi.fn(),
+    getDynamicProperty: vi.fn(),
+    setDynamicProperty: vi.fn(),
+    structureManager: {
+        place: vi.fn(),
+    },
+};
+
+export const system = {
+    currentTick: 0,
+    beforeEvents: {
+        startup: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+    },
+    afterEvents: {
+        scriptEventReceive: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+        playerPlaceBlock: { subscribe: vi.fn() },
+    },
+    runJob: vi.fn(),
+    run: vi.fn(),
+    runInterval: vi.fn(),
+    runTimeout: vi.fn(),
+    clearRun: vi.fn(),
+};
+
+export const EntityComponentTypes = {
+    Inventory: 'inventory',
+};
+
+export const ItemComponentTypes = {
+    Durability: 'durability',
+    Enchantable: 'enchantable',
+};
+
+export const CustomCommandSource = {
+    Block: 'Block',
+    Entity: 'Entity',
+    Server: 'Server',
+};
+
+export const CustomCommandStatus = {
+    Failure: 'Failure',
+    Success: 'Success',
+};
+
 export const DimensionTypes = {};
 export const ScriptEventSource = {};
 export const InputButton = {};
 export const ButtonState = {};
-export const EntityComponentTypes = {};
-export const ItemComponentTypes = {};
-export const TicksPerSecond = 20.0;
-export const Player = class {};
+export const TicksPerSecond = 20;
+export const ItemStack = {};
+export class Block {}
+export class Entity {}
+export class Player {
+    sendMessage = vi.fn();
+}

--- a/__mocks__/@minecraft/server.js
+++ b/__mocks__/@minecraft/server.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { vi } from 'vitest';
 
 export const world = {

--- a/__tests__/BP/scripts/include/data.test.js
+++ b/__tests__/BP/scripts/include/data.test.js
@@ -1,18 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import axios from 'axios';
 import { MC_VERSION } from '../../../../Canopy [BP]/scripts/constants.js';
 import { categoryToMobMap, meleeMobs } from '../../../../Canopy [BP]/scripts/include/data.js';
 import stripJsonComments from 'strip-json-comments';
-
-vi.mock('@minecraft/server', {
-    world: {},
-    ItemStack: {},
-    DimensionTypes: {}
-});
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
 
 const bedrockSamplesRawUrl = `https://raw.githubusercontent.com/Mojang/bedrock-samples/refs/tags/v${MC_VERSION}/`;
 

--- a/__tests__/BP/scripts/include/utils.test.js
+++ b/__tests__/BP/scripts/include/utils.test.js
@@ -5,15 +5,6 @@ import {
 	getScriptEventSourceName, getScriptEventSourceObject, recolor, titleCase, formatColorStr
 } from '../../../../Canopy [BP]/scripts/include/utils.js';
 
-vi.mock('@minecraft/server', {
-    world: {},
-    ItemStack: {},
-    DimensionTypes: {}
-});
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
 
 describe('calcDistance()', () => {
 	it.each([

--- a/__tests__/BP/scripts/lib/canopy/Canopy.test.js
+++ b/__tests__/BP/scripts/lib/canopy/Canopy.test.js
@@ -1,32 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import * as Canopy from "../../../../../Canopy [BP]/scripts/lib/canopy/Canopy";
-
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
 
 describe('Canopy module', () => {
     it('should export Commands', () => {

--- a/__tests__/BP/scripts/lib/canopy/Extension.test.js
+++ b/__tests__/BP/scripts/lib/canopy/Extension.test.js
@@ -3,29 +3,6 @@ import { Extension } from '../../../../../Canopy [BP]/scripts/lib/canopy/Extensi
 import { Command } from '../../../../../Canopy [BP]/scripts/lib/canopy/commands/Command.js';
 import { BooleanRule } from '../../../../../Canopy [BP]/scripts/lib/canopy/rules/BooleanRule.js';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
 describe('Extension', () => {
     const extensionData = {
         name: 'Test Extension',

--- a/__tests__/BP/scripts/lib/canopy/Extensions.test.js
+++ b/__tests__/BP/scripts/lib/canopy/Extensions.test.js
@@ -1,29 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Extensions } from "../../../../../Canopy [BP]/scripts/lib/canopy/Extensions.js";
 import { Extension } from "../../../../../Canopy [BP]/scripts/lib/canopy/Extension.js";
-
-vi.mock("@minecraft/server", () => ({
-    world: {
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
 
 describe("Extensions", () => {
     beforeEach(() => {

--- a/__tests__/BP/scripts/lib/canopy/commands/ArgumentParser.test.js
+++ b/__tests__/BP/scripts/lib/canopy/commands/ArgumentParser.test.js
@@ -1,28 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { ArgumentParser } from '../../../../../../Canopy [BP]/scripts/lib/canopy/commands/ArgumentParser.js';
-
-vi.mock("@minecraft/server", () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
 
 describe('ArgumentParser', () => {
     describe('parseCommandString', () => {

--- a/__tests__/BP/scripts/lib/canopy/commands/Command.test.js
+++ b/__tests__/BP/scripts/lib/canopy/commands/Command.test.js
@@ -6,29 +6,6 @@ import { Extension } from "../../../../../../Canopy [BP]/scripts/lib/canopy/Exte
 import { Extensions } from "../../../../../../Canopy [BP]/scripts/lib/canopy/Extensions";
 import { CommandCallbackRequest } from "../../../../../../Canopy [BP]/scripts/lib/canopy/extension.ipc";
 
-vi.mock("@minecraft/server", () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
 describe("Command", () => {
     beforeEach(() => {
         Commands.clear();

--- a/__tests__/BP/scripts/lib/canopy/commands/Commands.test.js
+++ b/__tests__/BP/scripts/lib/canopy/commands/Commands.test.js
@@ -3,38 +3,24 @@ import { Commands } from "../../../../../../Canopy [BP]/scripts/lib/canopy/comma
 import { BooleanRule } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/BooleanRule";
 import { Rules } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules";
 
-vi.mock("@minecraft/server", () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
         },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
+        system: {
+            ...original.system,
+            run: (callback) => callback()
         },
-        runJob: vi.fn(),
-        run: (callback) => callback()
-    },
-    CommandPermissionLevel: {
-        Any: 0,
-        GameDirectors: 1,
-        Admin: 2,
-        Host: 3,
-        Owner: 4
-    }
-}));
+        CommandPermissionLevel: { Any: 0, GameDirectors: 1, Admin: 2, Host: 3, Owner: 4 }
+    };
+});
 
 describe('Commands', () => {
     beforeEach(() => {

--- a/__tests__/BP/scripts/lib/canopy/commands/VanillaCommand.test.js
+++ b/__tests__/BP/scripts/lib/canopy/commands/VanillaCommand.test.js
@@ -14,50 +14,28 @@ const mockCustomCommandRegistry = {
     registerEnum: vi.fn()
 };
 
-vi.mock("@minecraft/server", () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
         },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
+        system: {
+            ...original.system,
+            beforeEvents: {
+                startup: {
+                    subscribe: () => ({ customCommandRegistry: mockCustomCommandRegistry }),
+                    unsubscribe: vi.fn()
                 }
             }
-        },
-        setDynamicProperty: vi.fn(),
-        getDynamicProperty: vi.fn()
-    },
-    system: {
-        beforeEvents: {
-            startup: {
-                subscribe: () => ({ customCommandRegistry: mockCustomCommandRegistry }),
-                unsubscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    },
-    CustomCommandSource: {
-        Block: "Block",
-        Entity: "Entity",
-        Server: "Server"
-    },
-    CustomCommandStatus: {
-        Failure: "Failure",
-        Success: "Success"
-    },
-    Block: class {},
-    Entity: class {},
-    Player: class { sendMessage = vi.fn() }
-}));
+        }
+    };
+});
 
 describe("VanillaCommand", () => {
     let mockCommand;

--- a/__tests__/BP/scripts/lib/canopy/help/CommandHelpEntry.test.js
+++ b/__tests__/BP/scripts/lib/canopy/help/CommandHelpEntry.test.js
@@ -1,29 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { CommandHelpEntry } from "../../../../../../Canopy [BP]/scripts/lib/canopy/help/CommandHelpEntry";
 import { Commands } from "../../../../../../Canopy [BP]/scripts/lib/canopy/commands/Commands";
-
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
 
 describe('CommandHelpEntry', () => {
     const mockCommand = {

--- a/__tests__/BP/scripts/lib/canopy/help/CommandHelpPage.test.js
+++ b/__tests__/BP/scripts/lib/canopy/help/CommandHelpPage.test.js
@@ -4,29 +4,6 @@ import { CommandHelpEntry } from "../../../../../../Canopy [BP]/scripts/lib/cano
 import { Command } from "../../../../../../Canopy [BP]/scripts/lib/canopy/commands/Command";
 import { Commands } from "../../../../../../Canopy [BP]/scripts/lib/canopy/commands/Commands";
 
-vi.mock("@minecraft/server", () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
 describe('CommandHelpPage', () => {
     describe('constructor', () => {
         it('should create an instance with title and description', () => {

--- a/__tests__/BP/scripts/lib/canopy/help/HelpBook.test.js
+++ b/__tests__/BP/scripts/lib/canopy/help/HelpBook.test.js
@@ -7,34 +7,6 @@ import { CommandHelpPage } from "../../../../../../Canopy [BP]/scripts/lib/canop
 import { Command } from "../../../../../../Canopy [BP]/scripts/lib/canopy/commands/Command";
 import { Commands } from "../../../../../../Canopy [BP]/scripts/lib/canopy/commands/Commands";
 
-vi.mock("@minecraft/server", () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
-
 // Terrible practice. This is a workaround for a Vitest rollup error that causes the Rule class to not be imported properly in BooleanRule.
 vi.mock('../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rule', () => ({
     Rule: class Rule {

--- a/__tests__/BP/scripts/lib/canopy/help/InfoDisplayRuleHelpEntry.test.js
+++ b/__tests__/BP/scripts/lib/canopy/help/InfoDisplayRuleHelpEntry.test.js
@@ -3,29 +3,6 @@ import { InfoDisplayRuleHelpEntry } from '../../../../../../Canopy [BP]/scripts/
 import { InfoDisplayRule } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/InfoDisplayRule';
 import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
 describe('InfoDisplayRuleHelpEntry', () => {
     let entry;
     beforeEach(() => {

--- a/__tests__/BP/scripts/lib/canopy/help/InfoDisplayRuleHelpPage.test.js
+++ b/__tests__/BP/scripts/lib/canopy/help/InfoDisplayRuleHelpPage.test.js
@@ -4,30 +4,6 @@ import { InfoDisplayRule } from '../../../../../../Canopy [BP]/scripts/lib/canop
 import { InfoDisplayRuleHelpEntry } from '../../../../../../Canopy [BP]/scripts/lib/canopy/help/InfoDisplayRuleHelpEntry';
 import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules';
 
-vi.mock("@minecraft/server", () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
 // Terrible practice. This is a workaround for a Vitest rollup error that causes the Rule class to not be imported properly in BooleanRule.
 vi.mock('../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rule', () => ({
     Rule: class Rule {

--- a/__tests__/BP/scripts/lib/canopy/help/RuleHelpPage.test.js
+++ b/__tests__/BP/scripts/lib/canopy/help/RuleHelpPage.test.js
@@ -4,30 +4,6 @@ import { RuleHelpEntry } from "../../../../../../Canopy [BP]/scripts/lib/canopy/
 import { BooleanRule } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/BooleanRule";
 import { Rules } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules";
 
-vi.mock("@minecraft/server", () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
 // Terrible practice. This is a workaround for a Vitest rollup error that causes the Rule class to not be imported properly in BooleanRule.
 vi.mock('../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rule', () => ({
     Rule: class Rule {

--- a/__tests__/BP/scripts/lib/canopy/rules/AbilityRule.test.js
+++ b/__tests__/BP/scripts/lib/canopy/rules/AbilityRule.test.js
@@ -2,37 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { AbilityRule } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/AbilityRule";
 import { Rules } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules";
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            },
-            playerInventoryItemChange: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            }
-        }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
-
 const onPlayerEnableCallback = vi.fn();
 const onPlayerDisableCallback = vi.fn();
 

--- a/__tests__/BP/scripts/lib/canopy/rules/BooleanRule.test.js
+++ b/__tests__/BP/scripts/lib/canopy/rules/BooleanRule.test.js
@@ -6,36 +6,20 @@ import { Extensions } from '../../../../../../Canopy [BP]/scripts/lib/canopy/Ext
 import { Extension } from '../../../../../../Canopy [BP]/scripts/lib/canopy/Extension.js';
 import { RuleValueSet } from '../../../../../../Canopy [BP]/scripts/lib/canopy/extension.ipc.js';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        },
-        setDynamicProperty: vi.fn(),
-        getDynamicProperty: vi.fn(() => false)
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
+            },
+            getDynamicProperty: vi.fn(() => false)
+        }
+    };
+});
 
 describe('BooleanRule', () => {
     const testExtension = new Extension({

--- a/__tests__/BP/scripts/lib/canopy/rules/GlobalRule.test.js
+++ b/__tests__/BP/scripts/lib/canopy/rules/GlobalRule.test.js
@@ -2,31 +2,19 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GlobalRule } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/GlobalRule";
 import { Rules } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules";
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        },
-        getDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
+        }
+    };
+});
 
 describe('GlobalRule', () => {
     beforeEach(() => {

--- a/__tests__/BP/scripts/lib/canopy/rules/InfoDisplayRule.test.js
+++ b/__tests__/BP/scripts/lib/canopy/rules/InfoDisplayRule.test.js
@@ -3,30 +3,19 @@ import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Ru
 import { InfoDisplayRule } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/InfoDisplayRule.js';
 import { BooleanRule } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/BooleanRule.js';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
         }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
+    };
+});
 
 describe('InfoDisplayRule', () => {
     let rule;

--- a/__tests__/BP/scripts/lib/canopy/rules/Rules.test.js
+++ b/__tests__/BP/scripts/lib/canopy/rules/Rules.test.js
@@ -3,34 +3,19 @@ import { Rules } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Ru
 import { BooleanRule } from "../../../../../../Canopy [BP]/scripts/lib/canopy/rules/BooleanRule.js";
 import { Rule } from "../../../../../../Canopy [BP]/scripts/lib/canopy/Canopy.js";
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
         }
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+    };
+});
 
 describe('Rules', () => {
     let testRule;

--- a/__tests__/BP/scripts/src/classes/EntityMovementLog.test.js
+++ b/__tests__/BP/scripts/src/classes/EntityMovementLog.test.js
@@ -1,48 +1,33 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
 import { EntityMovementLog } from "../../../../../Canopy [BP]/scripts/src/classes/EntityMovementLog";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        runTimeout: vi.fn((callback, timeout) => {
-            const timeoutId = setTimeout(callback, timeout * 50);
-            return {
-                clear: () => clearTimeout(timeoutId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        }),
-        currentTick: 0
-    },
-    world: {
-        afterEvents: {
-            entitySpawn: {
-                subscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            runTimeout: vi.fn((callback, timeout) => {
+                const timeoutId = setTimeout(callback, timeout * 50);
+                return { clear: () => clearTimeout(timeoutId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
         },
-        beforeEvents: {
-            entityRemove: {
-                subscribe: vi.fn()
-            },
-            playerLeave: {
-                subscribe: vi.fn()
-            }
-        },
-        getDimension: vi.fn(() => ({
-            getEntities: vi.fn(() => [
-                { typeId: 'minecraft:falling_block', id: 'entity1', location: { x: 1, y: 2, z: 3 }, dimension: { id: 'overworld' },
-                    getComponent: vi.fn(() => ({ })),
-                    isValid: vi.fn(() => true)
-                },
-                { typeId: 'minecraft:projectile', id: 'entity2', location: { x: 4, y: 5, z: 6 }, dimension: { id: 'overworld' },
-                    getComponent: vi.fn(() => ({ projectile: { isValid: true } })),
-                    isValid: vi.fn(() => true)
+        world: {
+            ...original.world,
+            getDimension: vi.fn(() => ({
+                getEntities: vi.fn(() => [
+                    { typeId: 'minecraft:falling_block', id: 'entity1', location: { x: 1, y: 2, z: 3 }, dimension: { id: 'overworld' },
+                        getComponent: vi.fn(() => ({ })),
+                        isValid: vi.fn(() => true)
+                    },
+                    { typeId: 'minecraft:projectile', id: 'entity2', location: { x: 4, y: 5, z: 6 }, dimension: { id: 'overworld' },
+                        getComponent: vi.fn(() => ({ projectile: { isValid: true } })),
+                        isValid: vi.fn(() => true)
                 },
                 { typeId: 'minecraft:item', id: 'entity3', location: { x: 7, y: 8, z: 9 }, dimension: { id: 'overworld' },
                     getComponent: vi.fn(() => ({ })),
@@ -51,7 +36,8 @@ vi.mock("@minecraft/server", () => ({
             ])
         }))
     }
-}));
+    };
+});
 
 describe('EntitMovementLog', () => {
     let entityLog;

--- a/__tests__/BP/scripts/src/classes/EntityTntLog.test.js
+++ b/__tests__/BP/scripts/src/classes/EntityTntLog.test.js
@@ -1,40 +1,24 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
 import { EntityTntLog } from "../../../../../Canopy [BP]/scripts/src/classes/EntityTntLog";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        runTimeout: vi.fn((callback, timeout) => {
-            const timeoutId = setTimeout(callback, timeout * 50);
-            return {
-                clear: () => clearTimeout(timeoutId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        })
-    },
-    world: {
-        afterEvents: {
-            entitySpawn: {
-                subscribe: vi.fn()
-            }
-        },
-        beforeEvents: {
-            entityRemove: {
-                subscribe: vi.fn()
-            },
-            playerLeave: {
-                subscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            runTimeout: vi.fn((callback, timeout) => {
+                const timeoutId = setTimeout(callback, timeout * 50);
+                return { clear: () => clearTimeout(timeoutId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
         }
-    }
-}));
+    };
+});
 
 vi.mock("@minecraft/server-ui", () => ({
     ModalFormData: vi.fn()

--- a/__tests__/BP/scripts/src/classes/InventoryUI.test.js
+++ b/__tests__/BP/scripts/src/classes/InventoryUI.test.js
@@ -2,40 +2,22 @@ import { InventoryUI } from "../../../../../Canopy [BP]/scripts/src/classes/Inve
 import { describe, it, expect, vi, afterEach } from "vitest";
 import * as Utils from "../../../../../Canopy [BP]/scripts/include/utils";
 
-vi.mock("@minecraft/server", () => ({
-    EntityComponentTypes: {
-        Inventory: 'inventory'
-    },
-    ItemComponentTypes: {
-        Durability: 'durability',
-        Enchantable: 'enchantable'
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn(),
-        currentTick: (Date.now() / 50),
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        }),
-        run: vi.fn((callback) => {
-            callback();
-        })
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            currentTick: (Date.now() / 50),
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); }),
+            run: vi.fn((callback) => { callback(); })
+        }
+    };
+});
 
 describe('InventoryPeeker', () => {
     afterEach(() => {

--- a/__tests__/BP/scripts/src/classes/Profiler.test.js
+++ b/__tests__/BP/scripts/src/classes/Profiler.test.js
@@ -1,30 +1,24 @@
 import { describe, it, expect, vi } from "vitest";
 import { Profiler } from "../../../../../Canopy [BP]/scripts/src/classes/Profiler";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        runTimeout: vi.fn((callback, timeout) => {
-            const timeoutId = setTimeout(callback, timeout * 50);
-            return {
-                clear: () => clearTimeout(timeoutId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        })
-    },
-    TicksPerSecond: 20.0
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            runTimeout: vi.fn((callback, timeout) => {
+                const timeoutId = setTimeout(callback, timeout * 50);
+                return { clear: () => clearTimeout(timeoutId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
+        }
+    };
+});
 
 describe('Profiler', () => {
     it('should have a getter for the instant MS', () => {

--- a/__tests__/BP/scripts/src/classes/TNTFuse.test.js
+++ b/__tests__/BP/scripts/src/classes/TNTFuse.test.js
@@ -1,45 +1,31 @@
 import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from "vitest";
 import { TNTFuse } from "../../../../../Canopy [BP]/scripts/src/classes/TNTFuse.js";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        currentTick: (Date.now() / 50),
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        })
-    },
-    world: {
-        afterEvents: {
-            entitySpawn: {
-                subscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            currentTick: (Date.now() / 50),
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
         },
-        beforeEvents: {
-            entityRemove: {
-                subscribe: vi.fn()
-            }
-        },
-        getDimension: vi.fn(() => ({
-            getEntities: vi.fn(() => [
-                { typeId: 'minecraft:tnt', id: 'entity1', location: { x: 1, y: 2, z: 3 }, dimension: { id: 'overworld' },
-                    isValid: vi.fn(() => true)
-                },
-                { typeId: 'minecraft:tnt', id: 'entity2', location: { x: 4, y: 5, z: 6 }, dimension: { id: 'overworld' },
-                    isValid: vi.fn(() => true)
-                },
-                { typeId: 'minecraft:tnt', id: 'entity3', location: { x: 7, y: 8, z: 9 }, dimension: { id: 'overworld' },
-                    isValid: vi.fn(() => false)
-                }
-            ])
-        }))
-    }
-}));
+        world: {
+            ...original.world,
+            getDimension: vi.fn(() => ({
+                getEntities: vi.fn(() => [
+                    { typeId: 'minecraft:tnt', id: 'entity1', location: { x: 1, y: 2, z: 3 }, dimension: { id: 'overworld' }, isValid: vi.fn(() => true) },
+                    { typeId: 'minecraft:tnt', id: 'entity2', location: { x: 4, y: 5, z: 6 }, dimension: { id: 'overworld' }, isValid: vi.fn(() => true) },
+                    { typeId: 'minecraft:tnt', id: 'entity3', location: { x: 7, y: 8, z: 9 }, dimension: { id: 'overworld' }, isValid: vi.fn(() => false) }
+                ])
+            }))
+        }
+    };
+});
 
 const tnt = { 
     typeId: 'minecraft:tnt',

--- a/__tests__/BP/scripts/src/commands/log.test.js
+++ b/__tests__/BP/scripts/src/commands/log.test.js
@@ -3,96 +3,46 @@ import { logCommand } from "../../../../../Canopy [BP]/scripts/src/commands/log"
 import { Player } from "@minecraft/server";
 import { PlayerCommandOrigin } from "../../../../../Canopy [BP]/scripts/lib/canopy/commands/PlayerCommandOrigin";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        runTimeout: vi.fn((callback, timeout) => {
-            const timeoutId = setTimeout(callback, timeout * 50);
-            return {
-                clear: () => clearTimeout(timeoutId)
-            };
-        }),
-        runJob: vi.fn(),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        }),
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            runTimeout: vi.fn((callback, timeout) => {
+                const timeoutId = setTimeout(callback, timeout * 50);
+                return { clear: () => clearTimeout(timeoutId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
         },
-        beforeEvents: {
-            startup: {
-                subscribe: vi.fn()
-            }
+        world: {
+            ...original.world,
+            getDimension: vi.fn(() => ({
+                id: 'overworld',
+                runCommand: vi.fn(),
+                getEntities: vi.fn(() => [
+                    { typeId: 'minecraft:falling_block', id: 'entity1', location: { x: 1, y: 2, z: 3 }, dimension: { id: 'overworld' },
+                        getComponent: vi.fn(() => ({})), isValid: vi.fn(() => true) },
+                    { typeId: 'minecraft:projectile', id: 'entity2', location: { x: 4, y: 5, z: 6 }, dimension: { id: 'overworld' },
+                        getComponent: vi.fn(() => ({ projectile: { isValid: true } })), isValid: vi.fn(() => true) },
+                    { typeId: 'minecraft:item', id: 'entity3', location: { x: 7, y: 8, z: 9 }, dimension: { id: 'overworld' },
+                        getComponent: vi.fn(() => ({})), isValid: vi.fn(() => false) }
+                ])
+            }))
+        },
+        CommandPermissionLevel: { Any: 'Any' },
+        CustomCommandParamType: { Enum: 'Enum', Integer: 'Integer' },
+        Player: class {
+            sendMessage = vi.fn();
+            getDynamicProperty = vi.fn();
+            setDynamicProperty = vi.fn();
         }
-    },
-    world: {
-        afterEvents: {
-            entitySpawn: {
-                subscribe: vi.fn()
-            },
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        beforeEvents: {
-            entityRemove: {
-                subscribe: vi.fn()
-            },
-            chatSend: {
-                subscribe: vi.fn()
-            },
-            playerLeave: {
-                subscribe: vi.fn()
-            }
-        },
-        getDimension: vi.fn(() => ({
-            id: 'overworld',
-            runCommand: vi.fn(),
-            getEntities: vi.fn(() => [
-                { typeId: 'minecraft:falling_block', id: 'entity1', location: { x: 1, y: 2, z: 3 }, dimension: { id: 'overworld' },
-                    getComponent: vi.fn(() => ({ })),
-                    isValid: vi.fn(() => true)
-                },
-                { typeId: 'minecraft:projectile', id: 'entity2', location: { x: 4, y: 5, z: 6 }, dimension: { id: 'overworld' },
-                    getComponent: vi.fn(() => ({ projectile: { isValid: true } })),
-                    isValid: vi.fn(() => true)
-                },
-                { typeId: 'minecraft:item', id: 'entity3', location: { x: 7, y: 8, z: 9 }, dimension: { id: 'overworld' },
-                    getComponent: vi.fn(() => ({ })),
-                    isValid: vi.fn(() => false)
-                }
-            ])
-        }))
-    },
-    CommandPermissionLevel: {
-        Any: 'Any',
-    },
-    CustomCommandParamType: {
-        Enum: 'Enum',
-        Integer: 'Integer',
-    },
-    CustomCommandStatus: {
-        Success: 'Success',
-        Failure: 'Failure',
-    },
-    Player: class {
-        sendMessage = vi.fn();
-        getDynamicProperty = vi.fn();
-        setDynamicProperty = vi.fn();
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+    };
+});
 
 describe('logCommand', () => {
     let mockPlayer;

--- a/__tests__/BP/scripts/src/commands/velocity.test.js
+++ b/__tests__/BP/scripts/src/commands/velocity.test.js
@@ -3,79 +3,32 @@ import { velocityCommand } from "../../../../../Canopy [BP]/scripts/src/commands
 import { Vector } from "../../../../../Canopy [BP]/scripts/lib/Vector";
 import { PlayerCommandOrigin } from "../../../../../Canopy [BP]/scripts/lib/canopy/Canopy";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        runTimeout: vi.fn((callback, timeout) => {
-            const timeoutId = setTimeout(callback, timeout * 50);
-            return {
-                clear: () => clearTimeout(timeoutId)
-            };
-        }),
-        runJob: vi.fn(),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        }),
-        run: vi.fn((callback) => callback()),
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            runTimeout: vi.fn((callback, timeout) => {
+                const timeoutId = setTimeout(callback, timeout * 50);
+                return { clear: () => clearTimeout(timeoutId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); }),
+            run: vi.fn((callback) => callback())
         },
-        beforeEvents: {
-            startup: {
-                subscribe: vi.fn()
-            }
+        CommandPermissionLevel: { GameDirectors: 'GameDirectors' },
+        CustomCommandParamType: { Enum: 'Enum', Float: 'Float' },
+        Player: class {
+            sendMessage = vi.fn();
+            getDynamicProperty = vi.fn();
+            setDynamicProperty = vi.fn();
         }
-    },
-    world: {
-        afterEvents: {
-            entitySpawn: {
-                subscribe: vi.fn()
-            },
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        beforeEvents: {
-            entityRemove: {
-                subscribe: vi.fn()
-            },
-            chatSend: {
-                subscribe: vi.fn()
-            },
-            playerLeave: {
-                subscribe: vi.fn()
-            }
-        },
-    },
-    CommandPermissionLevel: {
-        GameDirectors: 'GameDirectors',
-    },
-    CustomCommandParamType: {
-        Enum: 'Enum',
-        Float: 'Float',
-    },
-    CustomCommandStatus: {
-        Success: 'Success',
-        Failure: 'Failure',
-    },
-    Player: class {
-        sendMessage = vi.fn();
-        getDynamicProperty = vi.fn();
-        setDynamicProperty = vi.fn();
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+    };
+});
 
 describe('velocityCommand', () => {
     let mockPlayerOrigin;

--- a/__tests__/BP/scripts/src/events/PlayerChangeSubChunkEvent.test.js
+++ b/__tests__/BP/scripts/src/events/PlayerChangeSubChunkEvent.test.js
@@ -4,23 +4,25 @@ import { expect, it, describe, vi, beforeEach } from "vitest";
 const mockPlayer1 = { id: 'player1' };
 const mockPlayer2 = { id: 'player2' };
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        currentTick: (Date.now() / 50),
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        })
-    },
-    world: {
-        getAllPlayers: vi.fn(() => [void 0, mockPlayer1, mockPlayer2])
-    }
-}));
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            currentTick: (Date.now() / 50),
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
+        },
+        world: {
+            ...original.world,
+            getAllPlayers: vi.fn(() => [void 0, mockPlayer1, mockPlayer2])
+        }
+    };
+});
 
 describe('PlayerChangeSubChunkEvent', () => {
     let tracker;

--- a/__tests__/BP/scripts/src/events/PlayerStartSneakEvent.test.js
+++ b/__tests__/BP/scripts/src/events/PlayerStartSneakEvent.test.js
@@ -4,30 +4,27 @@ import { expect, test, describe, vi } from "vitest";
 const mockPlayer1 = { id: 'player1', inputInfo: { getButtonState: vi.fn(() => "Pressed" ) }, isOnGround: true, location: { x: 0, y: 0, z: 0 }, getRotation: vi.fn(() => ({ x: 0, y: 0 })) };
 const mockPlayer2 = { id: 'player2', inputInfo: { getButtonState: vi.fn(() => "Released" ) }, isOnGround: true, location: { x: 1, y: 1, z: 1 }, getRotation: vi.fn(() => ({ x: 0, y: 0 })) };
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        currentTick: (Date.now() / 50),
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        })
-    },
-    InputButton: {
-        Sneak: 'sneak'
-    },
-    ButtonState: {
-        Pressed: 'Pressed',
-        Released: 'Released'
-    },
-    world: {
-        getAllPlayers: vi.fn(() => [undefined, mockPlayer1, mockPlayer2])
-    }
-}));
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            currentTick: (Date.now() / 50),
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
+        },
+        InputButton: { Sneak: 'sneak' },
+        ButtonState: { Pressed: 'Pressed', Released: 'Released' },
+        world: {
+            ...original.world,
+            getAllPlayers: vi.fn(() => [undefined, mockPlayer1, mockPlayer2])
+        }
+    };
+});
 
 describe('PlayerStartSneakEvent', () => {
     test('should initialize properties correctly', () => {

--- a/__tests__/BP/scripts/src/events/SpawnEggSpawnEntityEvent.test.js
+++ b/__tests__/BP/scripts/src/events/SpawnEggSpawnEntityEvent.test.js
@@ -1,36 +1,30 @@
 import { SpawnEggSpawnEntityEvent, spawnEggSpawnEntityEvent } from "../../../../../Canopy [BP]/scripts/src/events/SpawnEggSpawnEntityEvent";
 import { expect, test, describe, vi, beforeEach } from "vitest";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        currentTick: (Date.now() / 50),
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        })
-    },
-    world: {
-        afterEvents: {
-            entitySpawn: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            },
-            playerInteractWithBlock: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            currentTick: (Date.now() / 50),
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
+        },
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                entitySpawn: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+                playerInteractWithBlock: { subscribe: vi.fn(), unsubscribe: vi.fn() }
             }
-        }
-    },
-    EntityInitializationCause: {
-        Spawned: 'Spawned',
-        Loaded: 'Loaded'
-    }
-}));
+        },
+        EntityInitializationCause: { Spawned: 'Spawned', Loaded: 'Loaded' }
+    };
+});
 
 describe('SpawnEggSpawnEntityEvent', () => {
     let tracker;

--- a/__tests__/BP/scripts/src/rules/allowBubbleColumnPlacement.test.js
+++ b/__tests__/BP/scripts/src/rules/allowBubbleColumnPlacement.test.js
@@ -1,45 +1,16 @@
 import { allowBubbleColumnPlacement } from "../../../../../Canopy [BP]/scripts/src/rules/allowBubbleColumnPlacement";
 import { expect, test, describe, vi, afterEach } from "vitest";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            },
-            playerPlaceBlock: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn(),
-        run: vi.fn((callback) => callback())
-    },
-    world: {
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            },
-            playerPlaceBlock: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn(),
-        setDynamicProperty: vi.fn(),
-        structureManager: {
-            place: vi.fn()
+vi.mock("@minecraft/server", async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            run: vi.fn((callback) => callback())
         }
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+    };
+});
 
 describe('allowBubbleColumnPlacement', () => {
     afterEach(() => {

--- a/__tests__/BP/scripts/src/rules/allowPeekInventory.test.js
+++ b/__tests__/BP/scripts/src/rules/allowPeekInventory.test.js
@@ -2,65 +2,38 @@ import { allowPeekInventory } from "../../../../../Canopy [BP]/scripts/src/rules
 import { expect, it, describe, vi, afterEach } from "vitest";
 import { InventoryUI } from "../../../../../Canopy [BP]/scripts/src/classes/InventoryUI";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            currentTick: (Date.now() / 50),
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); }),
+            run: vi.fn((callback) => { callback(); })
         },
-        runJob: vi.fn(),
-        currentTick: (Date.now() / 50),
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        }),
-        run: vi.fn((callback) => {
-            callback();
-        })
-    },
-    world: {
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            },
-            playerInteractWithBlock: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            },
-            playerInteractWithEntity: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
+        world: {
+            ...original.world,
+            beforeEvents: {
+                ...original.world.beforeEvents,
+                playerInteractWithBlock: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+                playerInteractWithEntity: { subscribe: vi.fn(), unsubscribe: vi.fn() }
             }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn(),
-        setDynamicProperty: vi.fn()
-    },
-    EntityComponentTypes: {
-        Inventory: 'inventory'
-    },
-    ItemComponentTypes: {
-        Durability: 'durability',
-        Enchantable: 'enchantable'
-    }
-}));
+        }
+    };
+});
 
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn(),
-    uiManager: {
-        closeAllForms: vi.fn()
-    }
-}));
+vi.mock("@minecraft/server-ui", async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        uiManager: { closeAllForms: vi.fn() }
+    };
+});
 
 describe('allowPeekInventory', () => {
     afterEach(() => {

--- a/__tests__/BP/scripts/src/rules/creativeNetherWaterPlacement.test.js
+++ b/__tests__/BP/scripts/src/rules/creativeNetherWaterPlacement.test.js
@@ -1,60 +1,26 @@
 import { creativeNetherWaterPlacement } from "../../../../../Canopy [BP]/scripts/src/rules/creativeNetherWaterPlacement";
 import { expect, test, describe, vi, afterEach } from "vitest";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            },
-            playerInteractWithBlock: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            run: vi.fn((callback) => callback())
+        },
+        world: {
+            ...original.world,
+            beforeEvents: {
+                ...original.world.beforeEvents,
+                playerInteractWithBlock: { subscribe: vi.fn(), unsubscribe: vi.fn() }
             }
         },
-        runJob: vi.fn(),
-        run: vi.fn((callback) => callback())
-    },
-    world: {
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            },
-            playerInteractWithBlock: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn(),
-        setDynamicProperty: vi.fn(),
-        structureManager: {
-            place: vi.fn()
-        }
-    },
-    GameMode: {
-        Creative: 'Creative',
-        Survival: 'Survival'
-    },
-    LiquidType: {
-        Water: 'Water'
-    },
-    Direction: {
-        Up: 'Up',
-        Down: 'Down',
-        North: 'North',
-        South: 'South',
-        West: 'West',
-        East: 'East'
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        GameMode: { Creative: 'Creative', Survival: 'Survival' },
+        LiquidType: { Water: 'Water' },
+        Direction: { Up: 'Up', Down: 'Down', North: 'North', South: 'South', West: 'West', East: 'East' }
+    };
+});
 
 describe('creativeNetherWaterPlacement', () => {
     afterEach(() => {

--- a/__tests__/BP/scripts/src/rules/dupeTnt.test.js
+++ b/__tests__/BP/scripts/src/rules/dupeTnt.test.js
@@ -3,52 +3,29 @@ import { spawnedEntitiesThisTick, handleTntDuplication } from '../../../../../Ca
 import { system, world } from '@minecraft/server';
 import { BooleanRule, Rules } from '../../../../../Canopy [BP]/scripts/lib/canopy/Canopy';
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(() => {
-                callback();
-            }, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        runTimeout: vi.fn((callback, timeout) => {
-            const timeoutId = setTimeout(() => {
-                callback();
-            }, timeout * 50);
-            return {
-                clear: () => clearTimeout(timeoutId)
-            };
-        }),
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(() => { callback(); }, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            runTimeout: vi.fn((callback, timeout) => {
+                const timeoutId = setTimeout(() => { callback(); }, timeout * 50);
+                return { clear: () => clearTimeout(timeoutId) };
+            })
         }
-    },
-    world: {
-        afterEvents: {
-            entitySpawn: {
-                subscribe: vi.fn()
-            },
-            pistonActivate: {
-                subscribe: vi.fn()
-            }
-        }
-    }
-}));
+    };
+});
 
 vi.mock('../../../../../Canopy [BP]/scripts/lib/canopy/Canopy', () => ({
     BooleanRule: vi.fn(),
     Rules: {
         getNativeValue: vi.fn()
     }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
 }));
 
 describe('dupeTnt Rule', () => {

--- a/__tests__/BP/scripts/src/rules/echoShardsEnableShriekers.test.js
+++ b/__tests__/BP/scripts/src/rules/echoShardsEnableShriekers.test.js
@@ -1,58 +1,29 @@
 import { vi, it, describe, expect } from "vitest";
 import { echoShardsEnableShriekers } from "../../../../../Canopy [BP]/scripts/src/rules/echoShardsEnableShriekers";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            run: vi.fn((callback) => callback())
+        },
+        world: {
+            ...original.world,
+            beforeEvents: {
+                ...original.world.beforeEvents,
+                playerInteractWithBlock: { subscribe: vi.fn(), unsubscribe: vi.fn() }
             }
         },
-        runJob: vi.fn(),
-        run: vi.fn((callback) => callback())
-    },
-    world: {
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            },
-            playerInteractWithBlock: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            }
+        BlockPermutation: {
+            resolve: (typeId, states) => ({ typeId: typeId, getAllStates: () => states })
         },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn(),
-        setDynamicProperty: vi.fn(),
-        structureManager: {
-            place: vi.fn()
-        }
-    },
-    BlockPermutation: {
-        resolve: (typeId, states) => ({
-            typeId: typeId,
-            getAllStates: () => states
-        })
-    },
-    EntityComponentTypes: {
-        Equippable: 'minecraft:equippable'
-    },
-    EquipmentSlot: {
-        Mainhand: 'mainhand'
-    },
-    GameMode: {
-        Creative: 'creative',
-        Survival: 'survival'
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        EntityComponentTypes: { ...original.EntityComponentTypes, Equippable: 'minecraft:equippable' },
+        EquipmentSlot: { Mainhand: 'mainhand' },
+        GameMode: { Creative: 'creative', Survival: 'survival' }
+    };
+});
 
 describe('echoShardsEnableShriekers', () => {
     it('should subscribe to player block placements when enabled', () => {

--- a/__tests__/BP/scripts/src/rules/entitySeparation.test.js
+++ b/__tests__/BP/scripts/src/rules/entitySeparation.test.js
@@ -2,42 +2,23 @@ import { vi, it, describe, expect, beforeEach } from "vitest";
 import { entitySeparation } from "../../../../../Canopy [BP]/scripts/src/rules/entitySeparation";
 import { Vector } from "../../../../../Canopy [BP]/scripts/lib/Vector";
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            run: vi.fn((callback) => callback())
         },
-        runJob: vi.fn(),
-        run: vi.fn((callback) => callback())
-    },
-    world: {
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                pressurePlatePush: { subscribe: vi.fn(), unsubscribe: vi.fn() }
             }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            },
-            pressurePlatePush: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn(),
-        setDynamicProperty: vi.fn(),
-        structureManager: {
-            place: vi.fn()
         }
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+    };
+});
 
 describe('entitySeparation', () => {
     let successfulEvent = {};

--- a/__tests__/BP/scripts/src/rules/infodisplay/BlockStates.test.js
+++ b/__tests__/BP/scripts/src/rules/infodisplay/BlockStates.test.js
@@ -3,38 +3,20 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { InfoDisplayElement } from '../../../../../../Canopy [BP]/scripts/src/rules/infodisplay/InfoDisplayElement';
 import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
         },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        },
-        setDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    },
-    LiquidType: {
-        Water: 'Water'
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        LiquidType: { Water: 'Water' }
+    };
+});
 
 const mockPlayer = {
     getBlockFromViewDirection: vi.fn(() => ({

--- a/__tests__/BP/scripts/src/rules/infodisplay/ChunkCoords.test.js
+++ b/__tests__/BP/scripts/src/rules/infodisplay/ChunkCoords.test.js
@@ -3,35 +3,19 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { InfoDisplayElement } from '../../../../../../Canopy [BP]/scripts/src/rules/infodisplay/InfoDisplayElement';
 import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        },
-        setDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        }
+    };
+});
 
 const mockPlayer = {
     location: {

--- a/__tests__/BP/scripts/src/rules/infodisplay/Dimension.test.js
+++ b/__tests__/BP/scripts/src/rules/infodisplay/Dimension.test.js
@@ -3,35 +3,19 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { InfoDisplayElement } from '../../../../../../Canopy [BP]/scripts/src/rules/infodisplay/InfoDisplayElement';
 import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        },
-        setDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        }
+    };
+});
 
 const mockPlayer = {
     dimension: {

--- a/__tests__/BP/scripts/src/rules/infodisplay/PeekInventory.test.js
+++ b/__tests__/BP/scripts/src/rules/infodisplay/PeekInventory.test.js
@@ -3,54 +3,26 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { InfoDisplayElement } from '../../../../../../Canopy [BP]/scripts/src/rules/infodisplay/InfoDisplayElement';
 import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
         },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        },
-        setDynamicProperty: vi.fn()
-    },
-    system: {
-        beforeEvents: {
-            startup: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    },
-    ItemStack: vi.fn((typeId, amount) => ({
-        typeId: typeId,
-        amount: amount || 1,
-        localizationKey: `item.${typeId.replace("minecraft:", '')}.name`
-    })),
-    CommandPermissionLevel: {
-        Any: 'Any'
-    },
-    CustomCommandParamType: {
-        String: 'String'
-    },
-    CustomCommandStatus: {
-        Failure: 'Failure'
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        ItemStack: vi.fn((typeId, amount) => ({
+            typeId: typeId,
+            amount: amount || 1,
+            localizationKey: `item.${typeId.replace("minecraft:", '')}.name`
+        })),
+        CommandPermissionLevel: { Any: 'Any' },
+        CustomCommandParamType: { String: 'String' }
+    };
+});
 
 const mockPlayer = {
     getBlockFromViewDirection: vi.fn(() => ({

--- a/__tests__/BP/scripts/src/rules/infodisplay/Speed.test.js
+++ b/__tests__/BP/scripts/src/rules/infodisplay/Speed.test.js
@@ -3,36 +3,19 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { InfoDisplayElement } from '../../../../../../Canopy [BP]/scripts/src/rules/infodisplay/InfoDisplayElement';
 import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        },
-        setDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    },
-    TicksPerSecond: 20
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        }
+    };
+});
 
 const mockPlayer = {
     getVelocity: vi.fn(() => ({ x: 0, y: 0, z: 0 })),

--- a/__tests__/BP/scripts/src/rules/infodisplay/Structures.test.js
+++ b/__tests__/BP/scripts/src/rules/infodisplay/Structures.test.js
@@ -3,35 +3,19 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { InfoDisplayElement } from '../../../../../../Canopy [BP]/scripts/src/rules/infodisplay/InfoDisplayElement';
 import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        },
-        setDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        }
+    };
+});
 
 const mockPlayer = {
     dimension: {

--- a/__tests__/BP/scripts/src/rules/infodisplay/Weather.test.js
+++ b/__tests__/BP/scripts/src/rules/infodisplay/Weather.test.js
@@ -3,35 +3,19 @@ import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { InfoDisplayElement } from '../../../../../../Canopy [BP]/scripts/src/rules/infodisplay/InfoDisplayElement';
 import { Rules } from '../../../../../../Canopy [BP]/scripts/lib/canopy/rules/Rules';
 
-vi.mock('@minecraft/server', () => ({
-    world: { 
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                worldLoad: { subscribe: (callback) => callback() }
             }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: (callback) => {
-                    callback();
-                }
-            }
-        },
-        setDynamicProperty: vi.fn()
-    },
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
-        },
-        runJob: vi.fn()
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        }
+    };
+});
 
 const mockPlayer = {
     dimension: {

--- a/__tests__/BP/scripts/src/rules/playerSit.test.js
+++ b/__tests__/BP/scripts/src/rules/playerSit.test.js
@@ -12,65 +12,36 @@ const rideableEntity = {
     setRotation: vi.fn()
 };
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            currentTick: (Date.now() / 50),
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
         },
-        runJob: vi.fn(),
-        currentTick: (Date.now() / 50),
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        })
-    },
-    world: {
-        getAllPlayers: vi.fn(() => [
-            undefined,
-            { id: 'player1', inputInfo: { getButtonState: vi.fn(() => "Pressed" ) }, isOnGround: true, location: { x: 0, y: 0, z: 0 }, getRotation: vi.fn(() => ({ x: 0, y: 0 })) },
-            { id: 'player2', inputInfo: { getButtonState: vi.fn(() => "Released" ) }, isOnGround: true, location: { x: 1, y: 1, z: 1 }, getRotation: vi.fn(() => ({ x: 0, y: 0 })) }
-        ]),
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
+        world: {
+            ...original.world,
+            getAllPlayers: vi.fn(() => [
+                undefined,
+                { id: 'player1', inputInfo: { getButtonState: vi.fn(() => "Pressed") }, isOnGround: true, location: { x: 0, y: 0, z: 0 }, getRotation: vi.fn(() => ({ x: 0, y: 0 })) },
+                { id: 'player2', inputInfo: { getButtonState: vi.fn(() => "Released") }, isOnGround: true, location: { x: 1, y: 1, z: 1 }, getRotation: vi.fn(() => ({ x: 0, y: 0 })) }
+            ]),
+            getDimension: vi.fn(() => ({
+                getEntities: vi.fn(() => [rideableEntity])
+            }))
         },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn(),
-        setDynamicProperty: vi.fn(),
-        getDimension: vi.fn(() => ({
-            getEntities: vi.fn(() => [rideableEntity])
-        }))
-    },
-    InputButton: {
-        Sneak: 'sneak'
-    },
-    ButtonState: {
-        Pressed: 'Pressed',
-        Released: 'Released'
-    },
-    EntityComponentTypes: {
-        Rideable: 'rideable'
-    },
-    DimensionTypes: {
-        getAll: vi.fn(() => [{ typeId: 'overworld' }])
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        InputButton: { Sneak: 'sneak' },
+        ButtonState: { Pressed: 'Pressed', Released: 'Released' },
+        EntityComponentTypes: { ...original.EntityComponentTypes, Rideable: 'rideable' },
+        DimensionTypes: { getAll: vi.fn(() => [{ typeId: 'overworld' }]) }
+    };
+});
 
 describe('playerSit', () => {
     beforeAll(() => {

--- a/__tests__/BP/scripts/src/rules/spawnEggSpawnWithMinecart.test.js
+++ b/__tests__/BP/scripts/src/rules/spawnEggSpawnWithMinecart.test.js
@@ -15,62 +15,30 @@ const mockMinecart = {
     }))
 };
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            },
-            playerPlaceBlock: {
-                subscribe: vi.fn()
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            run: vi.fn((callback) => callback()),
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
+        },
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                playerInteractWithBlock: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+                entitySpawn: { subscribe: vi.fn(), unsubscribe: vi.fn() }
             }
         },
-        runJob: vi.fn(),
-        run: vi.fn((callback) => callback()),
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        })
-    },
-    world: {
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
-            },
-            playerInteractWithBlock: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            },
-            entitySpawn: {
-                subscribe: vi.fn(),
-                unsubscribe: vi.fn()
-            }
-        },
-        getDynamicProperty: vi.fn(),
-        setDynamicProperty: vi.fn(),
-        structureManager: {
-            place: vi.fn()
-        }
-    },
-    EntityComponentTypes: {
-        Rideable: 'rideable',
-        Riding: 'riding'
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+        EntityComponentTypes: { ...original.EntityComponentTypes, Rideable: 'rideable', Riding: 'riding' }
+    };
+});
 
 describe('spawnEggSpawnWithMinecart', () => {
     afterEach(() => {

--- a/__tests__/BP/scripts/src/rules/tntFuse.test.js
+++ b/__tests__/BP/scripts/src/rules/tntFuse.test.js
@@ -13,50 +13,30 @@ const tntEntity = {
 };
 let tntFuseDP = false;
 
-vi.mock("@minecraft/server", () => ({
-    system: {
-        afterEvents: {
-            scriptEventReceive: {
-                subscribe: vi.fn()
-            }
+vi.mock('@minecraft/server', async (importOriginal) => {
+    const original = await importOriginal();
+    return {
+        ...original,
+        system: {
+            ...original.system,
+            currentTick: (Date.now() / 50),
+            runInterval: vi.fn((callback, interval) => {
+                const intervalId = setInterval(callback, interval * 50);
+                return { clear: () => clearInterval(intervalId) };
+            }),
+            clearRun: vi.fn((runner) => { runner.clear(); })
         },
-        runJob: vi.fn(),
-        currentTick: (Date.now() / 50),
-        runInterval: vi.fn((callback, interval) => {
-            const intervalId = setInterval(callback, interval * 50);
-            return {
-                clear: () => clearInterval(intervalId)
-            };
-        }),
-        clearRun: vi.fn((runner) => {
-            runner.clear();
-        })
-    },
-    world: {
-        beforeEvents: {
-            chatSend: {
-                subscribe: vi.fn()
-            }
-        },
-        afterEvents: {
-            worldLoad: {
-                subscribe: vi.fn()
+        world: {
+            ...original.world,
+            afterEvents: {
+                ...original.world.afterEvents,
+                entityLoad: { subscribe: vi.fn() }
             },
-            entitySpawn: {
-                subscribe: vi.fn()
-            },
-            entityLoad: {
-                subscribe: vi.fn()
-            }
-        },
-        setDynamicProperty: (identifier, ticks) => { tntFuseDP = ticks },
-        getDynamicProperty: () => tntFuseDP
-    }
-}));
-
-vi.mock("@minecraft/server-ui", () => ({
-    ModalFormData: vi.fn()
-}));
+            setDynamicProperty: (identifier, ticks) => { tntFuseDP = ticks },
+            getDynamicProperty: () => tntFuseDP
+        }
+    };
+});
 
 describe('tntFuseRule', () => {
     afterEach(() => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,20 +1,14 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  server: {
-    deps: {
-      external: ['@minecraft/server', '@minecraft/server-ui'],
-    }
-  },
   resolve: {
     alias: {
-      '@minecraft/server': `__mocks__/@minecraft/server`,
-      '@minecraft/server-ui': `__mocks__/@minecraft/server-ui`,
+      '@minecraft/server': `${__dirname}/__mocks__/@minecraft/server`,
+      '@minecraft/server-ui': `${__dirname}/__mocks__/@minecraft/server-ui`,
     }
   },
   test: {
-    testFiles: '**/__tests__/**/*.test.js',
-    files: '**/__tests__/**',
+    setupFiles: ['./vitest.setup.js'],
     env: {
       NODE_ENV: 'test'
     }

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,4 @@
+// Global test setup. Add shared configuration here.
+// Mock implementations live in __mocks__/@minecraft/server.js and __mocks__/@minecraft/server-ui.js.
+// Test files that need different mock behavior (e.g. subscribe callbacks called immediately)
+// can still override with vi.mock() locally.


### PR DESCRIPTION
## Summary

- Moved all per-file `vi.mock("@minecraft/server")` and `vi.mock("@minecraft/server-ui")` blocks out of individual test files and into centralized `__mocks__/@minecraft/server.js` and `__mocks__/@minecraft/server-ui.js` files
- Test files that need behavior different from the centralized mock now use Vitest's `importOriginal` helper to extend (rather than replace) the shared mock
- 14 test files had their mock blocks removed entirely — the centralized mock is sufficient
- 31+ test files were converted from full mock replacement to `importOriginal`-based partial overrides

## Why

Maintaining identical `vi.mock` boilerplate in 46 test files was error-prone and made updating mock behavior require touching every file. Centralizing the mocks means there's one place to update.

## Reviewer notes

- `vite.config.js` already had `resolve.alias` pointing `@minecraft/server` → `__mocks__/@minecraft/server.js`, so the centralized file is automatically used
- Test files that override specific parts use `importOriginal` spread rather than wholesale replacement
- All 55 test files pass (722 tests passed, 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)